### PR TITLE
Avoid collecting `v`

### DIFF
--- a/src/MarginalLogDensities.jl
+++ b/src/MarginalLogDensities.jl
@@ -290,7 +290,7 @@ function modal_hessian!(mld::MarginalLogDensity, w, p2)
 end
 
 function _marginalize(mld, v, data, method::LaplaceApprox, verbose)
-    p2 = (; p = data, v = collect(v))
+    p2 = (; p = data, v = v)
     verbose && println("Finding mode...")
     wopt, objective = optimize_marginal!(mld, p2)
     verbose && println("Calculating hessian...")


### PR DESCRIPTION
Here's a proposal fixing https://github.com/gdalle/DifferentiationInterface.jl/issues/594#issuecomment-2430989350

You probably want to add test cases with ComponentArrays to your test suite