### PR TITLE
Test on pre-release, not nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,12 +25,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
   # docs:


### PR DESCRIPTION
I noticed that you run tests on nightly, which is usually a bad idea for normal package developers. I suggest testing on `pre` instead, which automatically points to the latest pre-release. This PR updates the testing workflow, bumping actions to more recent versions when necessary.