### PR TITLE
Fix some README maths

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ mathematics, if we write `u -> logdensity(u, data)` as $f(u)$, then the marginal
 function `v -> marginal_logdensity(v, data)` is calculating
 
 $$
-f_m(u_2) = \int \int f(u) \; du_1 du_2.
+f_m(u_2) = \int \int f(u) \; du_1 du_3.
 $$
 
 By default, this package uses Laplace's method to approximate this integral. The Laplace approximation

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ while integrating over all possible values of `u[1]` and `u[3]`. In the laguage 
 mathematics, if we write `u -> logdensity(u, data)` as $f(u)$, then the marginalized 
 function `v -> marginal_logdensity(v, data)` is calculating
 
-$$
-f_m(u_2) = \int \int f(u) \; du_1 du_3.
-$$
+```math
+f_m(u_2) = \iint f(u) \; du_1 du_3.
+```
 
 By default, this package uses Laplace's method to approximate this integral. The Laplace approximation
 is fast in high dimensions, and works well for log-densities that are approximately Gaussian. The


### PR DESCRIPTION
For weird reasons GitHub Markdown maths doesn't show spaces correctly inside `$$...$$` (https://github.com/orgs/community/discussions/17143) so the solution is to use `math` code blocks. The variable is just a typo :)